### PR TITLE
[#108616770] Metrics whitelist and blacklist

### DIFF
--- a/jobs/carbon/spec
+++ b/jobs/carbon/spec
@@ -14,6 +14,8 @@ templates:
   config/carbon.conf.erb: conf/carbon.conf
   config/storage-aggregation.conf.erb: conf/storage-aggregation.conf
   config/storage-schemas.conf.erb: conf/storage-schemas.conf
+  config/blacklist.conf.erb: conf/blacklist.conf
+  config/whitelist.conf.erb: conf/whitelist.conf
 
 properties:
   carbon.cache.enable_log_rotation:
@@ -102,3 +104,11 @@ properties:
         pattern: "^my\\.metrics\\.*"
         xFilesFactor: "0.5"
         aggregationMethod: "average"
+
+  carbon.filter.enable:
+    description: Allows any of the carbon daemons to only accept metrics that are explicitly whitelisted and/or to reject blacklisted metrics.
+    default: False
+  carbon.filter.whitelist:
+    description: List of regular expressions of metrics we want to store. If empty, all metrics will be passed through.
+  carbon.filter.blacklist:
+    description: List of regular expressions of metrics we don't want to store.

--- a/jobs/carbon/templates/config/blacklist.conf.erb
+++ b/jobs/carbon/templates/config/blacklist.conf.erb
@@ -1,0 +1,5 @@
+<% if_p('carbon.filter.blacklist') do %>
+<% (p('carbon.filter.blacklist')).each do |line| %>
+<%= line %>
+<% end %>
+<% end %>

--- a/jobs/carbon/templates/config/carbon.conf.erb
+++ b/jobs/carbon/templates/config/carbon.conf.erb
@@ -165,7 +165,7 @@ WHISPER_FALLOCATE_CREATE = <%= p('carbon.cache.whisper_fallocate_create') %>
 # Set this to True to enable whitelisting and blacklisting of metrics in
 # CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
 # empty, all metrics will pass through
-# USE_WHITELIST = False
+USE_WHITELIST = <%= p('carbon.filter.enable') %>
 
 # By default, carbon itself will log statistics (such as a count,
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
@@ -282,7 +282,7 @@ USE_FLOW_CONTROL = True
 # Set this to True to enable whitelisting and blacklisting of metrics in
 # CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
 # empty, all metrics will pass through
-# USE_WHITELIST = False
+USE_WHITELIST = <%= p('carbon.filter.enable') %>
 
 # By default, carbon itself will log statistics (such as a count,
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
@@ -357,7 +357,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # Set this to True to enable whitelisting and blacklisting of metrics in
 # CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
 # empty, all metrics will pass through
-# USE_WHITELIST = False
+USE_WHITELIST = <%= p('carbon.filter.enable') %>
 
 # By default, carbon itself will log statistics (such as a count,
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60

--- a/jobs/carbon/templates/config/whitelist.conf.erb
+++ b/jobs/carbon/templates/config/whitelist.conf.erb
@@ -1,0 +1,5 @@
+<% if_p('carbon.filter.whitelist') do %>
+<% (p('carbon.filter.whitelist')).each do |line| %>
+<%= line %>
+<% end %>
+<% end %>


### PR DESCRIPTION
# What

Story: https://www.pivotaltracker.com/story/show/108616770

We want to avoid storing certain metrics because too many useless metrics make graphite really slow. Our use case here is the smoke tests that create a new application name everytime they run and fill the metrics directories with thousands of files.

We created a new release of graphite-statsd with customised templates to be able to change the whitelist/blacklist configuration via CF manifest properties.

There will be another PR to integrate this new release in cf-terraform.
# How to review

It is easy to test with the PR on cf-terraform.
To test independently:
- Jump on bastion
- Clone this repository/branch
- Inside the repository, run: `bosh create release --force`
- Run: `bosh upload release`
- Run: `bosh releases` and take note of the version number (ex: 0+dev.1)
- Edit cf-manifest.yml:

```
- default_networks:
...
  name: graphite
  properties:
    carbon:
      filter:
        enable: true
        blacklist:
        - stats\.counters\.cfstats\.router_.+\.[0-9]+\.http\.requests\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_trial_cf_paas_alphagov_co_uk.count.*
...
releases:
...
- name: graphite
  version: 0+dev.1
```

This would filter the smoke test apps because they are created with name starting as UUID.
- Run: `bosh deploy`

This can be tested by sending fake metrics to statsd on the graphite server:

```
echo "stats.counters.cfstats.router_z1.0.http.requests.031427f0-9ec4-47b6-4544-22c2b05cfbb0_trial_cf_paas_alphagov_co_uk.count 42 `date +%s`" | nc localhost 2003
```

Check the carbon creates log to see wether is creates new metrics or not.
# Who can review

Anyone but @saliceti or @keymon 
