### PR TITLE
[#108616770] Don't send statsd idle metrics

### DIFF
--- a/jobs/statsd/spec
+++ b/jobs/statsd/spec
@@ -13,3 +13,6 @@ properties:
   statsd.port:
     description: Port to listen for messages on over UDP.
     default: 8125
+  statsd.deleteIdleStats:
+    description: Don't send values to graphite for inactive counters, sets, gauges, or timers.
+    default: false

--- a/jobs/statsd/templates/config/config.js.erb
+++ b/jobs/statsd/templates/config/config.js.erb
@@ -107,4 +107,5 @@ Optional Variables:
     legacyNamespace: false
   }
 , flushInterval: 10000
+, deleteIdleStats: <%= p('statsd.deleteIdleStats') %>
 }


### PR DESCRIPTION
# What

Story: https://www.pivotaltracker.com/story/show/108616770

We want to avoid storing certain metrics because too many useless metrics make graphite really slow. Our use case here is the smoke tests that create a new application name everytime they run and fill the metrics directories with thousands of files.

When statsd receives a new metric, it will forward it to its backend forever, even if it never receives any more values. The property `deleteIdleStats` changes this behaviour so it stops sending values for inactive counters, sets, gauges, or timers.
There is a side effect: the missing values create "holes" in the graphs. This can be alleviated by using graphite functions `transformNull` for counters and `keepLastValue` for gauges.
We created a new release of graphite-statsd with customised templates to be able to change `deleteIdleStats` via CF manifest properties.

There will be another PR to integrate this new release in cf-terraform.
# How to review

It is easy to test with the PR on cf-terraform.
To test independently:
- Jump on bastion
- Clone this repository/branch
- Inside the repository, run: `bosh create release --force`
- Run: `bosh upload release`
- Run: `bosh releases` and take note of the version number (ex: 0+dev.1)
- Edit cf-manifest.yml:

```
- default_networks:
...
  name: graphite
  properties:
    statsd:
      deleteIdleStats: true
...
releases:
...
- name: graphite
  version: 0+dev.1
```
- Run: `bosh deploy`

This can be tested by sending fake metrics to statsd on the graphite server:

```
echo -n "deploys.test.mycounter:5|c" | nc -w 1 -u 10.0.10.40 8125 # counter
echo -n "deploys.test.mygauge:50|g" | nc -w 1 -u 10.0.10.40 8125 # gauge
```
# Who can review

Anyone but @saliceti or @keymon 
