### PR TITLE
[#108615900] Prune inactive metrics

### DIFF
--- a/jobs/carbon/spec
+++ b/jobs/carbon/spec
@@ -11,6 +11,7 @@ packages:
 
 templates:
   bin/carbon_ctl.erb: bin/carbon_ctl
+  bin/prune_metrics.erb: bin/prune_metrics
   config/carbon.conf.erb: conf/carbon.conf
   config/storage-aggregation.conf.erb: conf/storage-aggregation.conf
   config/storage-schemas.conf.erb: conf/storage-schemas.conf
@@ -112,3 +113,7 @@ properties:
     description: List of regular expressions of metrics we want to store. If empty, all metrics will be passed through.
   carbon.filter.blacklist:
     description: List of regular expressions of metrics we don't want to store.
+
+  carbon.prune_delay:
+    description: Inactive metrics will be deleted after this number of days.
+    default: -1

--- a/jobs/carbon/templates/bin/carbon_ctl.erb
+++ b/jobs/carbon/templates/bin/carbon_ctl.erb
@@ -23,6 +23,12 @@ case $1 in
     chown -RH vcap:vcap /var/vcap/sys/run/carbon
     chown -RH vcap:vcap /var/vcap/store/graphite
 
+    <% if p('carbon.prune_delay') != -1 %>
+    ln -sf /var/vcap/jobs/carbon/bin/prune_metrics /etc/cron.daily/prune_metrics
+    <% else %>
+    rm -f /etc/cron.daily/prune_metrics
+    <% end %>
+
     exec chpst -u vcap:vcap python /var/vcap/packages/carbon/bin/carbon-cache.py \
       --config=/var/vcap/packages/carbon/conf/carbon.conf start \
       1>> /var/vcap/sys/log/carbon/carbon_ctl.stdout.log \

--- a/jobs/carbon/templates/bin/prune_metrics.erb
+++ b/jobs/carbon/templates/bin/prune_metrics.erb
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+LOG_FILE=/var/vcap/sys/log/carbon/prune_metrics.log
+WHISPER_DIR=/var/vcap/store/graphite/storage/whisper
+DATE_FORMAT="%F %H:%M:%S %Z"
+LOG_STRING="File:\t[%TY-%Tm-%Td %TH:%TM:%.2TS %TZ] %kkb %h/%f\n"
+PRUNE_DELAY=<%= p('carbon.prune_delay') %>
+
+echo -ne "Now:\t" > ${LOG_FILE}
+echo [$(date +"${DATE_FORMAT}")] Starting to prune files older than ${PRUNE_DELAY} days in ${WHISPER_DIR} >> ${LOG_FILE}
+
+# Delete files older that PRUNE_DELAY days
+find ${WHISPER_DIR} -type f -mtime +${PRUNE_DELAY} -delete -printf "${LOG_STRING}" >> ${LOG_FILE}
+
+echo -ne "Now:\t" >> ${LOG_FILE}
+echo [$(date +"${DATE_FORMAT}")] Starting to delete empty directories in ${WHISPER_DIR} >> ${LOG_FILE}
+
+# Delete empty diretories
+find ${WHISPER_DIR} -type d -empty -delete -printf "${LOG_STRING}" >> ${LOG_FILE}
+
+echo -ne "Now:\t" >> ${LOG_FILE}
+echo [$(date +"${DATE_FORMAT}")] End >> ${LOG_FILE}


### PR DESCRIPTION
# What

Carbon handles retention times for each metric so the metric file keeps a constant size. But since the metrics are created dynamically, there may be cases where many useless metrics are created and they will be kept forever. This causes slowness and errors in Graphite.

This allows to detect inactive metrics and remove them. If the metric file hasn't been modified for a number of days, it will be deleted.

We create a cron job when carbon starts if the property 'carbon.prune_delay' is set, or remove it if the property isn't set.

This should be followed by:
- PR on https://github.com/alphagov/cf-terraform to update this release
- PR upstream in https://github.com/CloudCredo/graphite-statsd-boshrelease
# How to review
- Jump on bastion
- Clone this repository/branch
- Inside the repository, run: `bosh create release --force`
- Run: `bosh upload release`
- Run: `bosh releases` and take note of the version number (ex: 0+dev.1)
- Edit cf-manifest.yml:

```
- default_networks:
...
  name: graphite
  properties:
    carbon:
...
      prune_delay: 7
...
releases:
...
- name: graphite
  version: 0+dev.1
```
- Run: `bosh deploy`
- ssh to graphite: `bosh ssh graphite`
- Create fake metrics with fake timestamp if you don't have some already:

```
touch -mt 1511101618 /var/vcap/store/graphite/storage/whisper/cloudfoundry-colin-movember/old.wsp
touch -mt 1511261618 /var/vcap/store/graphite/storage/whisper/cloudfoundry-colin-movember/new.wsp
```
- Run daily cron:

```
run-parts /etc/cron.daily
```
- Check that old was deleted but new is still there
- Check the log in `/var/vcap/sys/log/carbon/prune_metrics.log`
# How can review

Aynone but @saliceti or @jimconner 
