### PR TITLE
[#118272895] Fix for BOSH 2.0

### DIFF
--- a/jobs/statsd/spec
+++ b/jobs/statsd/spec
@@ -16,3 +16,6 @@ properties:
   statsd.deleteIdleStats:
     description: Don't send values to graphite for inactive counters, sets, gauges, or timers.
     default: false
+  statsd.carbon_cache_line_receiver_port:
+    description: Port the carbon cache line receiver listens on.
+    default: 2003

--- a/jobs/statsd/templates/config/config.js.erb
+++ b/jobs/statsd/templates/config/config.js.erb
@@ -99,7 +99,7 @@ Optional Variables:
 
 */
 {
-  graphitePort: <%= p('carbon.cache.line_receiver_port') %>
+  graphitePort: <%= p('statsd.carbon_cache_line_receiver_port') %>
 , graphiteHost: "127.0.0.1"
 , port: <%= p('statsd.port') %>
 , backends: [ "./backends/graphite" ]


### PR DESCRIPTION
# What

Story: [Upgrade CF](https://www.pivotaltracker.com/story/show/118272895)

BOSH now doesn't allow a job template to access a property that is not in its own job spec.
This fixes an issue in this release.
# How to review

Deploy with recent BOSH, possibly along [_Upgrade CF to 235_ PR](https://github.com/alphagov/paas-cf/pull/259).
# Who can review

Anyone but @bleach or myself
