### PR TITLE
[#126296129] Fix graphite start script

### DIFF
--- a/jobs/graphite-web/templates/bin/graphite-web_ctl.erb
+++ b/jobs/graphite-web/templates/bin/graphite-web_ctl.erb
@@ -25,7 +25,8 @@ case $1 in
     # Set file permissions
     chown -RH vcap:vcap /var/vcap/sys/log/graphite-web
     chown -RH vcap:vcap /var/vcap/sys/run/graphite-web
-    chown -RH vcap:vcap /var/vcap/store/graphite
+    chown vcap:vcap /var/vcap/store/graphite
+    chown vcap:vcap /var/vcap/store/graphite/storage
     chown vcap:vcap /var/vcap/store/graphite/storage/index
     chown vcap:vcap /var/vcap/store/graphite/storage/rrd
     chown vcap:vcap /var/vcap/store/graphite/storage/whisper


### PR DESCRIPTION
# What

Story: [Fix timeouts starting graphite](https://www.pivotaltracker.com/story/show/126296129)

The recursive `chown` in the start script becomes very slow when there are lots of metrics. It is not needed, we replace it with simple `chown` on the top directories.
# How to review
- Deploy from https://github.com/alphagov/paas-cf/pull/360
- The issue is a bit tricky to reproduce as you need to combine a large number of files and a constant higher iowait. You can still check that graphite is not broken.
- Login to the VM and re-start graphite. It should start immediately and you should see metrics in the GUI
- Remove `/var/vcap/store/graphite` as if graphite was started for the first time, restart and check again
# Who can review

Anyone but @combor or myself
