### PR TITLE
[#126296129] Fix carbon slow start

### DIFF
--- a/jobs/carbon/templates/bin/carbon_ctl.erb
+++ b/jobs/carbon/templates/bin/carbon_ctl.erb
@@ -21,7 +21,7 @@ case $1 in
     # Set file permissions
     chown -RH vcap:vcap /var/vcap/sys/log/carbon
     chown -RH vcap:vcap /var/vcap/sys/run/carbon
-    chown -RH vcap:vcap /var/vcap/store/graphite
+    chown -H vcap:vcap /var/vcap/store/graphite
 
     <% if p('carbon.prune_delay') != -1 %>
     ln -sf /var/vcap/jobs/carbon/bin/prune_metrics /etc/cron.daily/prune_metrics


### PR DESCRIPTION
# What

Story: [Fix timeouts starting graphite](https://www.pivotaltracker.com/story/show/126296129)

This is the same issue as the one fixed in PR https://github.com/alphagov/paas-graphite-statsd-boshrelease/pull/6 but with carbon this time.
The recursive `chown` in the start script becomes very slow when there are lots of metrics. It is not needed, we replace it with simple `chown` on the top directory.
# How to review
- Check carbon starts quickly even with a great number of files in `/var/vcap/store/graphite`
- Check that carbon and graphite can still capture and display metrics
# Who can review

Anyone but @combor or myself
